### PR TITLE
fix the method of getting IP-address

### DIFF
--- a/cat-client/src/main/java/com/dianping/cat/configuration/NetworkInterfaceManager.java
+++ b/cat-client/src/main/java/com/dianping/cat/configuration/NetworkInterfaceManager.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 public enum NetworkInterfaceManager {
 	INSTANCE;
 	
+	//define the special ip and pattern
 	public final String LOCALHOST = "127.0.0.1";
 	public final String ANYHOST = "0.0.0.0";
 	private final Pattern IP_PATTERN = Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3,5}$");


### PR DESCRIPTION
最近我们用CAT监控我们系统的时候，发现一个问题：我们有几台机器，部署着我们的web项目，同时部署着LVS，这时候每个机器的网卡地址包含LVS的虚拟IP，以及机器的真实IP。
但是我们打开CAT-home监控页面的时候，发现上面显示的地址是LVS的地址，而非显示真实的IP地址。现在已经修改了获取IP地址的方法。